### PR TITLE
Prevent index ambiguity

### DIFF
--- a/incubator/orm/example_test.go
+++ b/incubator/orm/example_test.go
@@ -49,18 +49,18 @@ func NewGroupKeeper(storeKey sdk.StoreKey, cdc *codec.Codec) GroupKeeper {
 
 	groupTableBuilder := NewAutoUInt64TableBuilder(GroupTablePrefix, GroupTableSeqPrefix, storeKey, cdc, &GroupMetadata{})
 	// note: quite easy to mess with Index prefixes when managed outside. no fail fast on duplicates
-	k.groupByAdminIndex = NewIndex(groupTableBuilder, GroupByAdminIndexPrefix, func(val interface{}) ([][]byte, error) {
+	k.groupByAdminIndex = NewMultiKeyIndex(groupTableBuilder, GroupByAdminIndexPrefix, func(val interface{}) ([][]byte, error) {
 		return [][]byte{val.(*GroupMetadata).Admin}, nil
 	})
 	k.groupTable = groupTableBuilder.Build()
 
 	groupMemberTableBuilder := NewNaturalKeyTableBuilder(GroupMemberTablePrefix, GroupMemberTableSeqPrefix, GroupMemberTableIndexPrefix, storeKey, cdc, &GroupMember{})
 
-	k.groupMemberByGroupIndex = NewIndex(groupMemberTableBuilder, GroupMemberByGroupIndexPrefix, func(val interface{}) ([][]byte, error) {
+	k.groupMemberByGroupIndex = NewMultiKeyIndex(groupMemberTableBuilder, GroupMemberByGroupIndexPrefix, func(val interface{}) ([][]byte, error) {
 		group := val.(*GroupMember).Group
 		return [][]byte{group}, nil
 	})
-	k.groupMemberByMemberIndex = NewIndex(groupMemberTableBuilder, GroupMemberByMemberIndexPrefix, func(val interface{}) ([][]byte, error) {
+	k.groupMemberByMemberIndex = NewMultiKeyIndex(groupMemberTableBuilder, GroupMemberByMemberIndexPrefix, func(val interface{}) ([][]byte, error) {
 		return [][]byte{val.(*GroupMember).Member}, nil
 	})
 	k.groupMemberTable = groupMemberTableBuilder.Build()

--- a/incubator/orm/index.go
+++ b/incubator/orm/index.go
@@ -27,12 +27,12 @@ type MultiKeyIndex struct {
 	indexer   indexer
 }
 
-func NewIndex(builder Indexable, prefix byte, indexer IndexerFunc) *MultiKeyIndex {
+func NewMultiKeyIndex(builder Indexable, prefix byte, indexer IndexerFunc) *MultiKeyIndex {
 	idx := MultiKeyIndex{
 		storeKey:  builder.StoreKey(),
 		prefix:    prefix,
 		rowGetter: builder.RowGetter(),
-		indexer:   NewIndexer(indexer),
+		indexer:   NewMultiKeyIndexer(indexer),
 	}
 	builder.AddAfterSaveInterceptor(idx.onSave)
 	builder.AddAfterDeleteInterceptor(idx.onDelete)

--- a/incubator/orm/index.go
+++ b/incubator/orm/index.go
@@ -27,7 +27,7 @@ type MultiKeyIndex struct {
 	indexer   indexer
 }
 
-func NewMultiKeyIndex(builder Indexable, prefix byte, indexer IndexerFunc) *MultiKeyIndex {
+func NewMultiKeyIndex(builder Indexable, prefix byte, indexer MultiKeyIndexerFunc) *MultiKeyIndex {
 	idx := MultiKeyIndex{
 		storeKey:  builder.StoreKey(),
 		prefix:    prefix,

--- a/incubator/orm/index_test.go
+++ b/incubator/orm/index_test.go
@@ -18,7 +18,7 @@ func TestIndexPrefixScan(t *testing.T) {
 		testTableSeqPrefix
 	)
 	tBuilder := NewAutoUInt64TableBuilder(testTablePrefix, testTableSeqPrefix, storeKey, cdc, &GroupMetadata{})
-	idx := NewIndex(tBuilder, GroupByAdminIndexPrefix, func(val interface{}) ([][]byte, error) {
+	idx := NewMultiKeyIndex(tBuilder, GroupByAdminIndexPrefix, func(val interface{}) ([][]byte, error) {
 		return [][]byte{val.(*GroupMetadata).Admin}, nil
 	})
 	tb := tBuilder.Build()

--- a/incubator/orm/indexer.go
+++ b/incubator/orm/indexer.go
@@ -8,20 +8,20 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-// IndexerFunc creates one or multiple MultiKeyIndex keys for the source object.
-type IndexerFunc func(value interface{}) ([][]byte, error)
+// MultiKeyIndexerFunc creates one or multiple MultiKeyIndex keys for the source object.
+type MultiKeyIndexerFunc func(value interface{}) ([][]byte, error)
 
-// IndexerFunc creates exactly one index key for the source object.
+// MultiKeyIndexerFunc creates exactly one index key for the source object.
 type UniqueIndexerFunc func(value interface{}) ([]byte, error)
 
 // Indexer manages the persistence for an MultiKeyIndex based on searchable keys and operations.
 type Indexer struct {
-	indexerFunc IndexerFunc
+	indexerFunc MultiKeyIndexerFunc
 	addPolicy   func(store sdk.KVStore, secondaryIndexKey []byte, rowID uint64) error
 }
 
 // NewMultiKeyIndexer returns an indexer that supports multiple reference keys for an entity.
-func NewMultiKeyIndexer(indexerFunc IndexerFunc) *Indexer {
+func NewMultiKeyIndexer(indexerFunc MultiKeyIndexerFunc) *Indexer {
 	if indexerFunc == nil {
 		panic("indexer func must not be nil")
 	}
@@ -36,7 +36,7 @@ func NewUniqueIndexer(f UniqueIndexerFunc) *Indexer {
 	if f == nil {
 		panic("indexer func must not be nil")
 	}
-	adaptor := func(indexerFunc UniqueIndexerFunc) IndexerFunc {
+	adaptor := func(indexerFunc UniqueIndexerFunc) MultiKeyIndexerFunc {
 		return func(v interface{}) ([][]byte, error) {
 			k, err := indexerFunc(v)
 			return [][]byte{k}, err

--- a/incubator/orm/indexer.go
+++ b/incubator/orm/indexer.go
@@ -20,8 +20,8 @@ type Indexer struct {
 	addPolicy   func(store sdk.KVStore, secondaryIndexKey []byte, rowID uint64) error
 }
 
-// NewIndexer returns an indexer that supports multiple reference keys for an entity.
-func NewIndexer(indexerFunc IndexerFunc) *Indexer {
+// NewMultiKeyIndexer returns an indexer that supports multiple reference keys for an entity.
+func NewMultiKeyIndexer(indexerFunc IndexerFunc) *Indexer {
 	if indexerFunc == nil {
 		panic("indexer func must not be nil")
 	}


### PR DESCRIPTION
We have currently a multi-key and a unique key index. Calling it Index in a function is not very clear.

