### PR TITLE
Fix empty key in slice

### DIFF
--- a/incubator/orm/indexer.go
+++ b/incubator/orm/indexer.go
@@ -153,14 +153,15 @@ func makeIndexPrefixScanKey(indexKey []byte, rowID uint64) []byte {
 func pruneEmptyKeys(f IndexerFunc) IndexerFunc {
 	return func(v interface{}) ([][]byte, error) {
 		keys, err := f(v)
-		if err != nil {
-			return nil, err
+		if err != nil || keys == nil {
+			return keys, err
 		}
-		for i := 0; i < len(keys); i++ {
-			if len(keys[i]) == 0 {
-				keys = append(keys[0:i], keys[i+1:]...)
+		r := make([][]byte, 0, len(keys))
+		for i := range keys {
+			if len(keys[i]) != 0 {
+				r = append(r, keys[i])
 			}
 		}
-		return keys, nil
+		return r, nil
 	}
 }

--- a/incubator/orm/indexer.go
+++ b/incubator/orm/indexer.go
@@ -26,7 +26,7 @@ func NewIndexer(indexerFunc IndexerFunc) *Indexer {
 		panic("indexer func must not be nil")
 	}
 	return &Indexer{
-		indexerFunc: indexerFunc,
+		indexerFunc: pruneEmptyKeys(indexerFunc),
 		addPolicy:   multiKeyAddPolicy,
 	}
 }
@@ -43,7 +43,7 @@ func NewUniqueIndexer(f UniqueIndexerFunc) *Indexer {
 		}
 	}
 	return &Indexer{
-		indexerFunc: adaptor(f),
+		indexerFunc: pruneEmptyKeys(adaptor(f)),
 		addPolicy:   uniqueKeysAddPolicy,
 	}
 }
@@ -147,4 +147,20 @@ func makeIndexPrefixScanKey(indexKey []byte, rowID uint64) []byte {
 	copy(res, indexKey)
 	binary.BigEndian.PutUint64(res[n:], rowID)
 	return res
+}
+
+// pruneEmptyKeys drops any empty key from IndexerFunc f returned
+func pruneEmptyKeys(f IndexerFunc) IndexerFunc {
+	return func(v interface{}) ([][]byte, error) {
+		keys, err := f(v)
+		if err != nil {
+			return nil, err
+		}
+		for i := 0; i < len(keys); i++ {
+			if len(keys[i]) == 0 {
+				keys = append(keys[0:i], keys[i+1:]...)
+			}
+		}
+		return keys, nil
+	}
 }

--- a/incubator/orm/indexer_test.go
+++ b/incubator/orm/indexer_test.go
@@ -1,0 +1,303 @@
+package orm
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexerOnCreate(t *testing.T) {
+	const myRowID uint64 = 1
+
+	specs := map[string]struct {
+		srcFunc            IndexerFunc
+		expIndexKeys       [][]byte
+		expRowIDs          []uint64
+		expAddPolicyCalled bool
+		expErr             error
+	}{
+		"single key": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				return [][]byte{{0, 0, 0, 0, 0, 0, 0, 1}}, nil
+			},
+			expAddPolicyCalled: true,
+			expIndexKeys:       [][]byte{{0, 0, 0, 0, 0, 0, 0, 1}},
+			expRowIDs:          []uint64{myRowID},
+		},
+		"multi key": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				return [][]byte{{0, 0, 0, 0, 0, 0, 0, 1}, {1, 0, 0, 0, 0, 0, 0, 0}}, nil
+			},
+			expAddPolicyCalled: true,
+			expIndexKeys:       [][]byte{{0, 0, 0, 0, 0, 0, 0, 1}, {1, 0, 0, 0, 0, 0, 0, 0}},
+			expRowIDs:          []uint64{myRowID, myRowID},
+		},
+		"empty key in slice": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				return [][]byte{nil}, nil
+			},
+			expAddPolicyCalled: false,
+		},
+		"empty key": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				return [][]byte{}, nil
+			},
+			expAddPolicyCalled: false,
+		},
+		"nil key": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				return nil, nil
+			},
+			expAddPolicyCalled: false,
+		},
+		"error case": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				return nil, errors.New("test")
+			},
+			expErr:             errors.New("test"),
+			expAddPolicyCalled: false,
+		},
+	}
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			mockPolicy := &addPolicyRecorder{}
+			idx := NewIndexer(spec.srcFunc)
+			idx.addPolicy = mockPolicy.add
+
+			err := idx.OnCreate(nil, myRowID, nil)
+			if spec.expErr != nil {
+				require.Equal(t, spec.expErr, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, spec.expIndexKeys, mockPolicy.secondaryIndexKeys)
+			assert.Equal(t, spec.expRowIDs, mockPolicy.rowIDs)
+			assert.Equal(t, spec.expAddPolicyCalled, mockPolicy.called)
+		})
+	}
+}
+
+func TestIndexerOnDelete(t *testing.T) {
+	const myRowID uint64 = 1
+
+	specs := map[string]struct {
+		srcFunc      IndexerFunc
+		expIndexKeys [][]byte
+		expErr       error
+	}{
+		"single key": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				return [][]byte{{0, 0, 0, 0, 0, 0, 0, 1}}, nil
+			},
+			expIndexKeys: [][]byte{makeIndexPrefixScanKey([]byte{0, 0, 0, 0, 0, 0, 0, 1}, myRowID)},
+		},
+		"multi key": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				return [][]byte{{0, 0, 0, 0, 0, 0, 0, 1}, {1, 0, 0, 0, 0, 0, 0, 0}}, nil
+			},
+			expIndexKeys: [][]byte{
+				makeIndexPrefixScanKey([]byte{0, 0, 0, 0, 0, 0, 0, 1}, myRowID),
+				makeIndexPrefixScanKey([]byte{1, 0, 0, 0, 0, 0, 0, 0}, myRowID),
+			},
+		},
+		"empty key": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				return [][]byte{}, nil
+			},
+		},
+		"nil key": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				return nil, nil
+			},
+		},
+		"error case": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				return nil, errors.New("test")
+			},
+			expErr: errors.New("test"),
+		},
+	}
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			mockStore := &deleteKVStoreRecorder{}
+			idx := NewIndexer(spec.srcFunc)
+			err := idx.OnDelete(mockStore, myRowID, nil)
+			if spec.expErr != nil {
+				require.Equal(t, spec.expErr, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, spec.expIndexKeys, mockStore.deletes)
+		})
+	}
+}
+
+func TestIndexerOnUpdate(t *testing.T) {
+	const myRowID uint64 = 1
+
+	specs := map[string]struct {
+		srcFunc        IndexerFunc
+		expAddedKeys   [][]byte
+		expDeletedKeys [][]byte
+		expErr         error
+	}{
+		"single key - same key, no update": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				return [][]byte{{0, 0, 0, 0, 0, 0, 0, 1}}, nil
+			},
+		},
+		"single key - different key, replaced": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				keys := [][]byte{{0, 0, 0, 0, 0, 0, 0, 1}, {0, 0, 0, 0, 0, 0, 0, 2}}
+				i := value.(int)
+				return [][]byte{keys[i]}, nil
+			},
+			expAddedKeys: [][]byte{
+				makeIndexPrefixScanKey([]byte{0, 0, 0, 0, 0, 0, 0, 2}, myRowID),
+			},
+			expDeletedKeys: [][]byte{
+				makeIndexPrefixScanKey([]byte{0, 0, 0, 0, 0, 0, 0, 1}, myRowID),
+			},
+		},
+		//"multi key": {
+		//	srcFunc: func(value interface{}) ([][]byte, error) {
+		//		return [][]byte{{0, 0, 0, 0, 0, 0, 0, 1}, {1, 0, 0, 0, 0, 0, 0, 0}}, nil
+		//	},
+		//	expIndexKeys: [][]byte{
+		//		makeIndexPrefixScanKey([]byte{0, 0, 0, 0, 0, 0, 0, 1}, myRowID),
+		//		makeIndexPrefixScanKey([]byte{1, 0, 0, 0, 0, 0, 0, 0}, myRowID),
+		//	},
+		//},
+		"empty key": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				return [][]byte{}, nil
+			},
+		},
+		"nil key": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				return nil, nil
+			},
+		},
+		"error case": {
+			srcFunc: func(value interface{}) ([][]byte, error) {
+				return nil, errors.New("test")
+			},
+			expErr: errors.New("test"),
+		},
+	}
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			mockStore := &updateKVStoreRecorder{}
+			idx := NewIndexer(spec.srcFunc)
+			err := idx.OnUpdate(mockStore, myRowID, 1, 0)
+			if spec.expErr != nil {
+				require.Equal(t, spec.expErr, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, spec.expDeletedKeys, mockStore.deletes)
+			assert.Equal(t, spec.expAddedKeys, mockStore.stored.Keys())
+		})
+	}
+}
+
+type addPolicyRecorder struct {
+	secondaryIndexKeys [][]byte
+	rowIDs             []uint64
+	called             bool
+}
+
+func (c *addPolicyRecorder) add(store sdk.KVStore, key []byte, rowID uint64) error {
+	c.secondaryIndexKeys = append(c.secondaryIndexKeys, key)
+	c.rowIDs = append(c.rowIDs, rowID)
+	c.called = true
+	return nil
+}
+
+type updateKVStoreRecorder struct {
+	deleteKVStoreRecorder
+	stored tuples
+}
+
+func (u *updateKVStoreRecorder) Set(key, value []byte) {
+	u.stored = append(u.stored, tuple{key, value})
+}
+
+func (u updateKVStoreRecorder) Has(key []byte) bool {
+	for _, v := range u.stored {
+		if bytes.Equal(key, v.key) {
+			return true
+		}
+	}
+	return false
+}
+
+type deleteKVStoreRecorder struct {
+	alwaysPanicKVStore
+	deletes [][]byte
+}
+
+func (m *deleteKVStoreRecorder) Delete(key []byte) {
+	m.deletes = append(m.deletes, key)
+}
+
+type alwaysPanicKVStore struct{}
+
+func (a alwaysPanicKVStore) GetStoreType() types.StoreType {
+	panic("implement me")
+}
+
+func (a alwaysPanicKVStore) CacheWrap() types.CacheWrap {
+	panic("implement me")
+}
+
+func (a alwaysPanicKVStore) CacheWrapWithTrace(w io.Writer, tc types.TraceContext) types.CacheWrap {
+	panic("implement me")
+}
+
+func (a alwaysPanicKVStore) Get(key []byte) []byte {
+	panic("implement me")
+}
+
+func (a alwaysPanicKVStore) Has(key []byte) bool {
+	panic("implement me")
+}
+
+func (a alwaysPanicKVStore) Set(key, value []byte) {
+	panic("implement me")
+}
+
+func (a alwaysPanicKVStore) Delete(key []byte) {
+	panic("implement me")
+}
+
+func (a alwaysPanicKVStore) Iterator(start, end []byte) types.Iterator {
+	panic("implement me")
+}
+
+func (a alwaysPanicKVStore) ReverseIterator(start, end []byte) types.Iterator {
+	panic("implement me")
+}
+
+type tuple struct {
+	key, val []byte
+}
+
+type tuples []tuple
+
+func (t tuples) Keys() [][]byte {
+	if t == nil {
+		return nil
+	}
+	r := make([][]byte, len(t))
+	for i, v := range t {
+		r[i] = v.key
+	}
+	return r
+}

--- a/incubator/orm/testsupport.go
+++ b/incubator/orm/testsupport.go
@@ -1,6 +1,8 @@
 package orm
 
 import (
+	"io"
+
 	"github.com/cosmos/cosmos-sdk/store"
 	"github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -29,4 +31,42 @@ func (m MockContext) KVStore(key sdk.StoreKey) sdk.KVStore {
 		panic(err)
 	}
 	return m.store.GetCommitKVStore(key)
+}
+
+type AlwaysPanicKVStore struct{}
+
+func (a AlwaysPanicKVStore) GetStoreType() types.StoreType {
+	panic("Not implemented")
+}
+
+func (a AlwaysPanicKVStore) CacheWrap() types.CacheWrap {
+	panic("Not implemented")
+}
+
+func (a AlwaysPanicKVStore) CacheWrapWithTrace(w io.Writer, tc types.TraceContext) types.CacheWrap {
+	panic("Not implemented")
+}
+
+func (a AlwaysPanicKVStore) Get(key []byte) []byte {
+	panic("Not implemented")
+}
+
+func (a AlwaysPanicKVStore) Has(key []byte) bool {
+	panic("Not implemented")
+}
+
+func (a AlwaysPanicKVStore) Set(key, value []byte) {
+	panic("Not implemented")
+}
+
+func (a AlwaysPanicKVStore) Delete(key []byte) {
+	panic("Not implemented")
+}
+
+func (a AlwaysPanicKVStore) Iterator(start, end []byte) types.Iterator {
+	panic("Not implemented")
+}
+
+func (a AlwaysPanicKVStore) ReverseIterator(start, end []byte) types.Iterator {
+	panic("Not implemented")
 }


### PR DESCRIPTION
This patch fixes an issue with secondary index keys that are nil or empty. They are ignored now.

* Added tests for indexers
