### PR TITLE
Minor cleanups

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - orm_develop
   pull_request:
     branches:
       - '*'

--- a/incubator/orm/go.mod
+++ b/incubator/orm/go.mod
@@ -4,8 +4,7 @@ go 1.13
 
 require (
 	github.com/cosmos/cosmos-sdk v0.34.4-0.20191013030331-92ea174ea6e6
-	github.com/gogo/protobuf v1.3.0
-	github.com/magiconair/properties v1.8.1
+	github.com/gogo/protobuf v1.3.1
 	github.com/stretchr/testify v1.4.0
 	github.com/tendermint/tm-db v0.2.0
 )

--- a/incubator/orm/go.sum
+++ b/incubator/orm/go.sum
@@ -85,6 +85,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.0 h1:G8O7TerXerS4F6sx9OV7/nRfJdnXgHZu/S/7F2SN+UE=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
+github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/incubator/orm/index.go
+++ b/incubator/orm/index.go
@@ -27,11 +27,11 @@ type MultiKeyIndex struct {
 }
 
 // NewIndex builds a MultiKeyIndex
-func NewIndex(builder Indexable, prefix byte, indexer IndexerFunc) *MultiKeyIndex {
+func NewIndex(builder Indexable, prefix byte, indexer IndexerFunc) MultiKeyIndex {
 	return newIndex(builder, prefix, NewIndexer(indexer, builder.IndexKeyCodec()))
 }
 
-func newIndex(builder Indexable, prefix byte, indexer *Indexer) *MultiKeyIndex {
+func newIndex(builder Indexable, prefix byte, indexer *Indexer) MultiKeyIndex {
 	codec := builder.IndexKeyCodec()
 	if codec == nil {
 		panic("IndexKeyCodec must not be nil")
@@ -54,7 +54,7 @@ func newIndex(builder Indexable, prefix byte, indexer *Indexer) *MultiKeyIndex {
 	}
 	builder.AddAfterSaveInterceptor(idx.onSave)
 	builder.AddAfterDeleteInterceptor(idx.onDelete)
-	return &idx
+	return idx
 }
 
 // Has checks if a key exists. Panics on nil key.
@@ -133,9 +133,9 @@ type UniqueIndex struct {
 }
 
 // NewUniqueIndex create a new Index object where duplicate keys are prohibited.
-func NewUniqueIndex(builder Indexable, prefix byte, uniqueIndexerFunc UniqueIndexerFunc) *UniqueIndex {
-	return &UniqueIndex{
-		MultiKeyIndex: *newIndex(builder, prefix, NewUniqueIndexer(uniqueIndexerFunc, builder.IndexKeyCodec())),
+func NewUniqueIndex(builder Indexable, prefix byte, uniqueIndexerFunc UniqueIndexerFunc) UniqueIndex {
+	return UniqueIndex{
+		MultiKeyIndex: newIndex(builder, prefix, NewUniqueIndexer(uniqueIndexerFunc, builder.IndexKeyCodec())),
 	}
 }
 

--- a/incubator/orm/index_test.go
+++ b/incubator/orm/index_test.go
@@ -201,7 +201,7 @@ func TestIndexPrefixScan(t *testing.T) {
 func TestUniqueIndex(t *testing.T) {
 	storeKey := sdk.NewKVStoreKey("test")
 
-	tableBuilder := NewNaturalKeyTableBuilder(GroupMemberTablePrefix, storeKey, &testdata.GroupMember{},Max255DynamicLengthIndexKeyCodec{})
+	tableBuilder := NewNaturalKeyTableBuilder(GroupMemberTablePrefix, storeKey, &testdata.GroupMember{}, Max255DynamicLengthIndexKeyCodec{})
 	uniqueIdx := NewUniqueIndex(tableBuilder, 0x10, func(val interface{}) (RowID, error) {
 		return []byte{val.(*testdata.GroupMember).Member[0]}, nil
 	})

--- a/incubator/orm/natural_key_test.go
+++ b/incubator/orm/natural_key_test.go
@@ -16,7 +16,7 @@ func TestNaturalKeyTablePrefixScan(t *testing.T) {
 		testTablePrefix = iota
 	)
 
-	tb := NewNaturalKeyTableBuilder(testTablePrefix, storeKey, &testdata.GroupMember{},Max255DynamicLengthIndexKeyCodec{}).
+	tb := NewNaturalKeyTableBuilder(testTablePrefix, storeKey, &testdata.GroupMember{}, Max255DynamicLengthIndexKeyCodec{}).
 		Build()
 
 	ctx := NewMockContext()

--- a/incubator/orm/sequence_test.go
+++ b/incubator/orm/sequence_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSequenceIncrements(t *testing.T) {

--- a/incubator/orm/table_test.go
+++ b/incubator/orm/table_test.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/modules/incubator/orm/testdata"
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/incubator/orm/testdata/codec.pb.go
+++ b/incubator/orm/testdata/codec.pb.go
@@ -5,12 +5,11 @@ package testdata
 
 import (
 	fmt "fmt"
-	io "io"
-	math "math"
-
 	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
+	io "io"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/incubator/orm/testdata/codec.pb.go
+++ b/incubator/orm/testdata/codec.pb.go
@@ -5,11 +5,12 @@ package testdata
 
 import (
 	fmt "fmt"
+	io "io"
+	math "math"
+
 	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
-	io "io"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/incubator/orm/uint64_index.go
+++ b/incubator/orm/uint64_index.go
@@ -20,12 +20,12 @@ func UInt64MultiKeyAdapter(indexer UInt64IndexerFunc) IndexerFunc {
 
 // UInt64Index is a typed index.
 type UInt64Index struct {
-	multiKeyIndex *MultiKeyIndex
+	multiKeyIndex MultiKeyIndex
 }
 
 // NewUInt64Index creates a typed secondary index
-func NewUInt64Index(builder Indexable, prefix byte, indexer UInt64IndexerFunc) *UInt64Index {
-	return &UInt64Index{
+func NewUInt64Index(builder Indexable, prefix byte, indexer UInt64IndexerFunc) UInt64Index {
+	return UInt64Index{
 		multiKeyIndex: NewIndex(builder, prefix, UInt64MultiKeyAdapter(indexer)),
 	}
 }


### PR DESCRIPTION
This started with the index constructors but I added some other minor cleanups.

* Return non pointer values from index constructors
* As we are not merging to master I also added the `orm_develop` branch for CI.
* Upgrade gogo/protobuf and regenerate test models
* Drop unwanted `github.com/magiconair/properties/assert` dependency (not intentionally added by me but from my IDE)

Resolves #15 

