### PR TITLE
Import/ export table data to genesis

### DIFF
--- a/incubator/orm/auto_uint64.go
+++ b/incubator/orm/auto_uint64.go
@@ -21,7 +21,7 @@ func NewAutoUInt64TableBuilder(prefixData byte, prefixSeq byte, storeKey sdk.Sto
 
 type AutoUInt64TableBuilder struct {
 	*TableBuilder
-	seq *Sequence
+	seq Sequence
 }
 
 // Build create the AutoUInt64Table object.
@@ -32,10 +32,13 @@ func (a AutoUInt64TableBuilder) Build() AutoUInt64Table {
 	}
 }
 
+var _ SequenceExportable = &AutoUInt64Table{}
+var _ TableExportable = &AutoUInt64Table{}
+
 // AutoUInt64Table is the table type which an auto incrementing ID.
 type AutoUInt64Table struct {
 	table Table
-	seq   *Sequence
+	seq   Sequence
 }
 
 // Create a new persistent object with an auto generated uint64 primary key. They key is returned.
@@ -113,4 +116,14 @@ func (a AutoUInt64Table) PrefixScan(ctx HasKVStore, start, end uint64) (Iterator
 // CONTRACT: No writes may happen within a domain while an iterator exists over it.
 func (a AutoUInt64Table) ReversePrefixScan(ctx HasKVStore, start uint64, end uint64) (Iterator, error) {
 	return a.table.ReversePrefixScan(ctx, EncodeSequence(start), EncodeSequence(end))
+}
+
+// Sequence returns the sequence used by this table
+func (a AutoUInt64Table) Sequence() Sequence {
+	return a.seq
+}
+
+// Table satisfies the TableExportable interface and must not be used otherwise.
+func (a AutoUInt64Table) Table() Table {
+	return a.table
 }

--- a/incubator/orm/genesis.go
+++ b/incubator/orm/genesis.go
@@ -1,0 +1,135 @@
+package orm
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	"github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+)
+
+// Model defines the IO structure for table imports and exports
+type Model struct {
+	Key   []byte          `json:"key", yaml:"key"`
+	Value json.RawMessage `json:"value", yaml:"value"`
+}
+
+// TableExportable
+type TableExportable interface {
+	// Table returns the table to export
+	Table() Table
+}
+
+// SequenceExportable
+type SequenceExportable interface {
+	// Sequence returns the sequence to export
+	Sequence() Sequence
+}
+
+// ExportTableData returns a json encoded `[]Model` slice of all the data persisted in the table.
+// When the given table implements the `SequenceExportable` interface then it's current value
+// is returned as well or otherwise defaults to 0.
+func ExportTableData(ctx HasKVStore, t TableExportable) (json.RawMessage, uint64, error) {
+	enc := jsonpb.Marshaler{}
+	var r []Model
+	forEachInTable(ctx, t.Table(), func(rowID RowID, obj Persistent) error {
+		pbObj, ok := obj.(proto.Message)
+		if !ok {
+			return errors.Wrapf(ErrType, "not a proto message type: %T", pbObj)
+		}
+		var buf bytes.Buffer
+		err := enc.Marshal(&buf, pbObj)
+		if err != nil {
+			return errors.Wrap(err, "json encoding")
+		}
+		r = append(r, Model{Key: rowID, Value: buf.Bytes()})
+		return nil
+	})
+	var seqValue uint64
+	if st, ok := t.(SequenceExportable); ok {
+		seqValue = st.Sequence().CurVal(ctx)
+	}
+	b, err := json.Marshal(r)
+	return b, seqValue, err
+}
+
+// ImportTableData initializes a table and attached indexers from the given json encoded `[]Model`s.
+// The seqValue is optional and only used with tables that implement the `SequenceExportable` interface.
+func ImportTableData(ctx HasKVStore, t TableExportable, src json.RawMessage, seqValue uint64) error {
+	dec := json.NewDecoder(bytes.NewReader(src))
+	if _, err := dec.Token(); err != nil {
+		return errors.Wrap(err, "open bracket")
+	}
+	table := t.Table()
+	if err := clearAllInTable(ctx, table); err != nil {
+		return errors.Wrap(err, "clear old entries")
+	}
+	for dec.More() {
+		var m Model
+		if err := dec.Decode(&m); err != nil {
+			return errors.Wrap(err, "decode")
+		}
+		if err := putIntoTable(ctx, table, m); err != nil {
+			return errors.Wrap(err, "insert from genesis model")
+		}
+	}
+	if _, err := dec.Token(); err != nil {
+		return errors.Wrap(err, "closing bracket")
+	}
+	if st, ok := t.(SequenceExportable); ok {
+		if err := st.Sequence().InitVal(ctx, seqValue); err != nil {
+			return errors.Wrap(err, "sequence")
+		}
+	}
+	return nil
+}
+
+// forEachInTable iterates through all entries in the given table and calls the callback function.
+// Aborts on first error.
+func forEachInTable(ctx HasKVStore, table Table, f func(RowID, Persistent) error) error {
+	store := prefix.NewStore(ctx.KVStore(table.storeKey), []byte{table.prefix})
+	it := store.Iterator(nil, nil)
+	defer it.Close()
+	for ; it.Valid(); it.Next() {
+		obj := reflect.New(table.model).Interface().(Persistent)
+		if err := obj.Unmarshal(it.Value()); err != nil {
+			return errors.Wrap(err, "unmarshal")
+		}
+		if err := f(it.Key(), obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// clearAllInTable deletes all entries in a table with delete interceptors called
+func clearAllInTable(ctx HasKVStore, table Table) error {
+	store := prefix.NewStore(ctx.KVStore(table.storeKey), []byte{table.prefix})
+	it := store.Iterator(nil, nil)
+	defer it.Close()
+	for ; it.Valid(); it.Next() {
+		if err := table.Delete(ctx, it.Key()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// putIntoTable inserts the model into the table with all save interceptors called
+func putIntoTable(ctx HasKVStore, table Table, m Model) error {
+	pbDec := jsonpb.Unmarshaler{}
+
+	obj := reflect.New(table.model).Interface().(Persistent)
+	pbObj, ok := obj.(proto.Message)
+	if !ok {
+		return errors.Wrapf(ErrType, "not a proto message type: %T", pbObj)
+	}
+
+	if err := pbDec.Unmarshal(bytes.NewReader(m.Value), pbObj); err != nil {
+		return errors.Wrapf(err, "can not unmarshal %s into %T", string(m.Value), obj)
+	}
+	return table.Create(ctx, m.Key, obj)
+}

--- a/incubator/orm/genesis_test.go
+++ b/incubator/orm/genesis_test.go
@@ -1,0 +1,82 @@
+package orm
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/modules/incubator/orm/testdata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportTableData(t *testing.T) {
+	storeKey := sdk.NewKVStoreKey("test")
+	const prefix = iota
+	table := NewTableBuilder(prefix, storeKey, &testdata.GroupMetadata{}, FixLengthIndexKeys(1)).Build()
+
+	ctx := NewMockContext()
+	testRecordsNum := 2
+	testRecords := make([]testdata.GroupMetadata, testRecordsNum)
+	for i := 1; i <= testRecordsNum; i++ {
+		myAddr := sdk.AccAddress(bytes.Repeat([]byte{byte(i)}, sdk.AddrLen))
+		g := testdata.GroupMetadata{
+			Description: fmt.Sprintf("my test %d", i),
+			Admin:       myAddr,
+		}
+		err := table.Create(ctx, []byte{byte(i)}, &g)
+		require.NoError(t, err)
+		testRecords[i-1] = g
+	}
+
+	jsonModels, _, err := ExportTableData(ctx, table)
+	require.NoError(t, err)
+	exp := `[
+	{
+	"key" : "AQ==",
+	"value": {"admin":"cosmos1qyqszqgpqyqszqgpqyqszqgpqyqszqgpjnp7du", "description":"my test 1"}
+	},
+	{
+	"key":"Ag==", 
+	"value": {"admin":"cosmos1qgpqyqszqgpqyqszqgpqyqszqgpqyqszrh8mx2", "description":"my test 2"}
+	}
+]`
+	assert.JSONEq(t, exp, string(jsonModels))
+}
+
+func TestImportTableData(t *testing.T) {
+	storeKey := sdk.NewKVStoreKey("test")
+	const prefix = iota
+	table := NewTableBuilder(prefix, storeKey, &testdata.GroupMetadata{}, FixLengthIndexKeys(1)).Build()
+
+	ctx := NewMockContext()
+
+	jsonModels := `[
+	{
+	"key" : "AQ==",
+	"value": {"admin":"cosmos1qyqszqgpqyqszqgpqyqszqgpqyqszqgpjnp7du", "description":"my test 1"}
+	},
+	{
+	"key":"Ag==", 
+	"value": {"admin":"cosmos1qgpqyqszqgpqyqszqgpqyqszqgpqyqszrh8mx2", "description":"my test 2"}
+	}
+]`
+	// when
+	err := ImportTableData(ctx, table, []byte(jsonModels), 0)
+	require.NoError(t, err)
+
+	// then
+	for i := 1; i < 3; i++ {
+		var loaded testdata.GroupMetadata
+		err := table.GetOne(ctx, []byte{byte(i)}, &loaded)
+		require.NoError(t, err)
+
+		exp := testdata.GroupMetadata{
+			Description: fmt.Sprintf("my test %d", i),
+			Admin:       sdk.AccAddress(bytes.Repeat([]byte{byte(i)}, sdk.AddrLen)),
+		}
+		require.Equal(t, exp, loaded)
+	}
+
+}

--- a/incubator/orm/orm.go
+++ b/incubator/orm/orm.go
@@ -32,6 +32,11 @@ type HasKVStore interface {
 // Unique identifier of a persistent table.
 type RowID []byte
 
+// Bytes returns raw bytes.
+func (r RowID) Bytes() []byte {
+	return r
+}
+
 // Persistent supports Marshal and Unmarshal
 //
 // This is separated from Marshal, as this almost always requires

--- a/incubator/orm/sequence.go
+++ b/incubator/orm/sequence.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // sequenceStorageKey is a fix key to read/ write data on the storage layer
@@ -16,8 +17,8 @@ type Sequence struct {
 	prefix   byte
 }
 
-func NewSequence(storeKey sdk.StoreKey, prefix byte) *Sequence {
-	return &Sequence{
+func NewSequence(storeKey sdk.StoreKey, prefix byte) Sequence {
+	return Sequence{
 		prefix:   prefix,
 		storeKey: storeKey,
 	}
@@ -38,6 +39,21 @@ func (s Sequence) CurVal(ctx HasKVStore) uint64 {
 	store := prefix.NewStore(ctx.KVStore(s.storeKey), []byte{s.prefix})
 	v := store.Get(sequenceStorageKey)
 	return DecodeSequence(v)
+}
+
+// InitVal sets the start value for the sequence. It must be called only once on an empty DB.
+// Otherwise an error is returned when the key exits. The given start value is stored as current
+// value.
+//
+// It is recommended to call this method only for a sequence start value other than `1` as the
+// method consumes unnecessary gas otherwise. A scenario would be an import from genesis.
+func (s Sequence) InitVal(ctx HasKVStore, seq uint64) error {
+	store := prefix.NewStore(ctx.KVStore(s.storeKey), []byte{s.prefix})
+	if store.Has(sequenceStorageKey) {
+		return errors.Wrap(ErrUniqueConstraint, "already initialized")
+	}
+	store.Set(sequenceStorageKey, EncodeSequence(seq))
+	return nil
 }
 
 // DecodeSequence converts the binary representation into an Uint64 value.

--- a/incubator/orm/sequence.go
+++ b/incubator/orm/sequence.go
@@ -24,7 +24,7 @@ func NewSequence(storeKey sdk.StoreKey, prefix byte) Sequence {
 	}
 }
 
-// NextVal increments the counter by one and returns the value.
+// NextVal increments and persists the counter by one and returns the value.
 func (s Sequence) NextVal(ctx HasKVStore) uint64 {
 	store := prefix.NewStore(ctx.KVStore(s.storeKey), []byte{s.prefix})
 	v := store.Get(sequenceStorageKey)
@@ -34,11 +34,18 @@ func (s Sequence) NextVal(ctx HasKVStore) uint64 {
 	return seq
 }
 
-// CurVal returns the last value used. 0Nex if none.
+// CurVal returns the last value used. 0 if none.
 func (s Sequence) CurVal(ctx HasKVStore) uint64 {
 	store := prefix.NewStore(ctx.KVStore(s.storeKey), []byte{s.prefix})
 	v := store.Get(sequenceStorageKey)
 	return DecodeSequence(v)
+}
+
+// PeekNextVal returns the CurVal + increment step. Not persistent.
+func (s Sequence) PeekNextVal(ctx HasKVStore) uint64 {
+	store := prefix.NewStore(ctx.KVStore(s.storeKey), []byte{s.prefix})
+	v := store.Get(sequenceStorageKey)
+	return DecodeSequence(v) + 1
 }
 
 // InitVal sets the start value for the sequence. It must be called only once on an empty DB.

--- a/incubator/orm/table.go
+++ b/incubator/orm/table.go
@@ -78,6 +78,8 @@ func (a *TableBuilder) AddAfterDeleteInterceptor(interceptor AfterDeleteIntercep
 	a.afterDelete = append(a.afterDelete, interceptor)
 }
 
+var _ TableExportable = &Table{}
+
 // Table is the high level object to storage mapper functionality. Persistent entities are stored by an unique identifier
 // called `RowID`.
 // The Table struct does not enforce uniqueness of the `RowID` but expects this to be satisfied by the callers and conditions
@@ -229,6 +231,10 @@ func (a Table) ReversePrefixScan(ctx HasKVStore, start, end RowID) (Iterator, er
 		rowGetter: NewTypeSafeRowGetter(a.storeKey, a.prefix, a.model),
 		it:        store.ReverseIterator(start, end),
 	}, nil
+}
+
+func (a Table) Table() Table {
+	return a
 }
 
 // typeSafeIterator is initialized with a type safe RowGetter only.


### PR DESCRIPTION
All modules in SDK need to [support](https://github.com/cosmos/cosmos-sdk/blob/master/types/module/module.go#L131-L132) data import from genesis and export to a json format. With this PR the `orm` framework is extended to support the data IO with:
* ExportTableData
* ImportTableData

functions. They work with our 3 different table types.

Minor additions included (from working on groups)
* new `NaturalKeyTable.Contains(ctx, obj) bool`
* new` RowID.Bytes() []byte`
* new `Sequence.PeekNextVal(ctx) uint64`