### PR TITLE
Spike: weave like orm query handler

### DIFF
--- a/incubator/group/querier.go
+++ b/incubator/group/querier.go
@@ -2,16 +2,12 @@ package group
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/cosmos/modules/incubator/orm"
 )
 
 func NewQuerier(k Keeper) sdk.Querier {
-	return func(ctx sdk.Context, path []string, req abci.RequestQuery) ([]byte, error) {
-		switch path[0] {
-		// TODO: define supported queries and return types
-		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown query path: %s", path[0])
-		}
-	}
+	qh := orm.NewQueryHandler()
+	qh.AddTableRoute("xgroup", k.groupTable)
+	qh.AddIndexRoute("xgroup/admin", k.groupByAdminIndex)
+	return qh.Handle
 }

--- a/incubator/group/querier_test.go
+++ b/incubator/group/querier_test.go
@@ -28,7 +28,7 @@ func TestQuerier(t *testing.T) {
 	ctx := NewContext(pKey, pTKey, groupKey)
 	k.setParams(ctx, DefaultParams())
 
-	_, err := k.CreateGroup(ctx, []byte("one-admin-address"), nil, "example1")
+	_, err := k.CreateGroup(ctx, []byte("one--admin--address"), nil, "example1")
 	require.NoError(t, err)
 	_, err = k.CreateGroup(ctx, []byte("other-admin-address"), nil, "example2")
 	require.NoError(t, err)
@@ -60,7 +60,7 @@ func TestQuerier(t *testing.T) {
 		},
 		"query index for single entity": {
 			srcPath:     "xgroup/admin",
-			srcData:     []byte("one-admin-address"),
+			srcData:     []byte("one--admin--address"),
 			expModelLen: 1,
 		},
 		"query index to find all in range": {

--- a/incubator/group/querier_test.go
+++ b/incubator/group/querier_test.go
@@ -28,9 +28,9 @@ func TestQuerier(t *testing.T) {
 	ctx := NewContext(pKey, pTKey, groupKey)
 	k.setParams(ctx, DefaultParams())
 
-	_, err := k.CreateGroup(ctx, []byte("one--admin--address"), nil, "example1")
+	_, err := k.CreateGroup(ctx, []byte("one---admin--address"), nil, "example1")
 	require.NoError(t, err)
-	_, err = k.CreateGroup(ctx, []byte("other-admin-address"), nil, "example2")
+	_, err = k.CreateGroup(ctx,  []byte("other--admin-address"), nil, "example2")
 	require.NoError(t, err)
 
 	q := NewQuerier(k)
@@ -60,7 +60,7 @@ func TestQuerier(t *testing.T) {
 		},
 		"query index for single entity": {
 			srcPath:     "xgroup/admin",
-			srcData:     []byte("one--admin--address"),
+			srcData:     []byte("one---admin--address"),
 			expModelLen: 1,
 		},
 		"query index to find all in range": {
@@ -83,10 +83,10 @@ func TestQuerier(t *testing.T) {
 			srcData:     []byte("o"),
 			expModelLen: 1,
 			expMore:     true,
-			expCursor:   encoding.EncodeToString(append([]byte("other-admin-address"), orm.EncodeSequence(2)...)),
+			expCursor:   encoding.EncodeToString(append([]byte("other--admin-address"), orm.EncodeSequence(2)...)),
 		},
 		"query index with cursor": {
-			srcPath:     fmt.Sprintf("xgroup/admin?prefix&cursor=%s", encoding.EncodeToString(append([]byte("other-admin-address"), orm.EncodeSequence(2)...))),
+			srcPath:     fmt.Sprintf("xgroup/admin?prefix&cursor=%s", encoding.EncodeToString(append([]byte("other--admin-address"), orm.EncodeSequence(2)...))),
 			srcData:     []byte("o"),
 			expModelLen: 1,
 		},

--- a/incubator/group/querier_test.go
+++ b/incubator/group/querier_test.go
@@ -1,0 +1,81 @@
+package group
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	"github.com/cosmos/cosmos-sdk/x/params/subspace"
+	"github.com/cosmos/modules/incubator/orm"
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+func TestQuerier(t *testing.T) {
+	amino := codec.New()
+	pKey, pTKey := sdk.NewKVStoreKey(params.StoreKey), sdk.NewTransientStoreKey(params.TStoreKey)
+	paramSpace := subspace.NewSubspace(amino, pKey, pTKey, DefaultParamspace)
+
+	groupKey := sdk.NewKVStoreKey(StoreKeyName)
+	k := NewGroupKeeper(groupKey, paramSpace, baseapp.NewRouter(), &MockProposalI{})
+	ctx := NewContext(pKey, pTKey, groupKey)
+	k.setParams(ctx, DefaultParams())
+
+	_, err := k.CreateGroup(ctx, []byte("one-admin-address"), nil, "example1")
+	require.NoError(t, err)
+	_, err = k.CreateGroup(ctx, []byte("other-admin-address"), nil, "example2")
+	require.NoError(t, err)
+
+	q := NewQuerier(k)
+	specs := map[string]struct {
+		srcPath     string
+		srcData     []byte
+		expModelLen int
+		expErr      *errors.Error
+	}{
+		"query table for single entry": {
+			srcPath:     "xgroup",
+			srcData:     orm.EncodeSequence(1),
+			expModelLen: 1,
+		},
+		"query table to find all in range": {
+			srcPath:     "xgroup?range",
+			expModelLen: 2,
+		},
+		"query table to find all with prefix": {
+			srcPath:     "xgroup?prefix",
+			srcData:     []byte{0},
+			expModelLen: 2,
+		},
+		"query index for single entity": {
+			srcPath:     "xgroup/admin",
+			srcData:     []byte("one-admin-address"),
+			expModelLen: 1,
+		},
+		"query index to find all in range": {
+			srcPath:     "xgroup/admin?range",
+			expModelLen: 2,
+		},
+		"query index to find all with prefix": {
+			srcPath:     "xgroup/admin?prefix",
+			srcData:     []byte("o"),
+			expModelLen: 2,
+		},
+	}
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			data, err := q(ctx, []string{spec.srcPath}, abci.RequestQuery{Path: spec.srcPath, Data: spec.srcData})
+			require.True(t, spec.expErr.Is(err), "unexpected error", err)
+			t.Logf("%s", string(data))
+			var res map[string]interface{}
+			require.NoError(t, json.Unmarshal(data, &res))
+			require.Contains(t, res, "data")
+			require.Len(t, res["data"], spec.expModelLen)
+		},
+		)
+	}
+}

--- a/incubator/orm/go.mod
+++ b/incubator/orm/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/cosmos/cosmos-sdk v0.34.4-0.20191013030331-92ea174ea6e6
 	github.com/gogo/protobuf v1.3.1
 	github.com/stretchr/testify v1.4.0
+	github.com/tendermint/tendermint v0.32.6
 	github.com/tendermint/tm-db v0.2.0
 )

--- a/incubator/orm/index.go
+++ b/incubator/orm/index.go
@@ -157,7 +157,7 @@ func (i indexIterator) LoadNext(dest Persistent) (RowID, error) {
 	indexPrefixKey := i.it.Key()
 	rowID := i.keyCodec.StripRowID(indexPrefixKey)
 	i.it.Next()
-	return rowID, i.rowGetter(i.ctx, rowID, dest)
+	return rowID, i.rowGetter.Get(i.ctx, rowID, dest)
 }
 
 // Close releases the iterator and should be called at the end of iteration

--- a/incubator/orm/iterator.go
+++ b/incubator/orm/iterator.go
@@ -21,6 +21,10 @@ func (i IteratorFunc) LoadNext(dest Persistent) (RowID, error) {
 func (i IteratorFunc) Close() error {
 	return nil
 }
+// NextPosition return the current position
+func (i IteratorFunc) NextPosition() Cursor {
+	return nil
+}
 
 func NewRawValueIterator(rowID RowID, val []byte) Iterator {
 	var closed bool
@@ -86,6 +90,10 @@ func (i *LimitedIterator) LoadNext(dest Persistent) (RowID, error) {
 	}
 	i.remainingCount--
 	return i.parentIterator.LoadNext(dest)
+}
+
+func (i LimitedIterator) NextPosition() Cursor {
+	return i.parentIterator.NextPosition()
 }
 
 // Close releases the iterator and should be called at the end of iteration

--- a/incubator/orm/iterator_test.go
+++ b/incubator/orm/iterator_test.go
@@ -135,7 +135,7 @@ func mockIter(rowID RowID, val Persistent) Iterator {
 	if err != nil {
 		panic(err)
 	}
-	return NewSingleValueIterator(rowID, b)
+	return NewRawValueIterator(rowID, b)
 }
 
 func noopIter() Iterator {

--- a/incubator/orm/orm.go
+++ b/incubator/orm/orm.go
@@ -131,26 +131,47 @@ type AfterDeleteInterceptor func(ctx HasKVStore, rowID RowID, value Persistent) 
 
 // RowGetter loads a persistent object by row ID into the destination object. The dest parameter must therefore be a pointer.
 // Any implementation must return `ErrNotFound` when no object for the rowID exists
-type RowGetter func(ctx HasKVStore, rowID RowID, dest Persistent) error
+type RowGetter interface {
+	Get(ctx HasKVStore, rowID RowID, dest Persistent) error
+	Type() reflect.Type
+}
+
+type TypeSafeRowGetter struct {
+	storeKey  sdk.StoreKey
+	prefixKey byte
+	model     reflect.Type
+}
+
+// TableRowGetter returns a type safe `RowGetter` for the table.
+func TableRowGetter(table Table) TypeSafeRowGetter {
+	return NewTypeSafeRowGetter(table.storeKey, table.prefix, table.model)
+}
 
 // NewTypeSafeRowGetter returns a `RowGetter` with type check on the dest parameter.
-func NewTypeSafeRowGetter(storeKey sdk.StoreKey, prefixKey byte, model reflect.Type) RowGetter {
-	return func(ctx HasKVStore, rowID RowID, dest Persistent) error {
-		if len(rowID) == 0 {
-			return errors.Wrap(ErrArgument, "key must not be nil")
-		}
-		if err := assertCorrectType(model, dest); err != nil {
-			return err
-		}
+func NewTypeSafeRowGetter(storeKey sdk.StoreKey, prefixKey byte, model reflect.Type) TypeSafeRowGetter {
+	return TypeSafeRowGetter{storeKey, prefixKey, model}
+}
 
-		store := prefix.NewStore(ctx.KVStore(storeKey), []byte{prefixKey})
-		it := store.Iterator(prefixRange(rowID))
-		defer it.Close()
-		if !it.Valid() {
-			return ErrNotFound
-		}
-		return dest.Unmarshal(it.Value())
+func (t TypeSafeRowGetter) Get(ctx HasKVStore, rowID RowID, dest Persistent) error {
+	if len(rowID) == 0 {
+		return errors.Wrap(ErrArgument, "key must not be nil")
 	}
+	if err := assertCorrectType(t.model, dest); err != nil {
+		return err
+	}
+
+	store := prefix.NewStore(ctx.KVStore(t.storeKey), []byte{t.prefixKey})
+	it := store.Iterator(prefixRange(rowID))
+	defer it.Close()
+	if !it.Valid() {
+		return ErrNotFound
+	}
+	return dest.Unmarshal(it.Value())
+
+}
+
+func (t TypeSafeRowGetter) Type() reflect.Type {
+	return t.model
 }
 
 func assertCorrectType(model reflect.Type, obj Persistent) error {

--- a/incubator/orm/orm.go
+++ b/incubator/orm/orm.go
@@ -100,6 +100,9 @@ type Iterator interface {
 	// are no more items the ErrIteratorDone error is returned
 	// The key is the rowID and not any MultiKeyIndex key.
 	LoadNext(dest Persistent) (RowID, error)
+
+	// NextPosition return a cursor to the next value
+	NextPosition() Cursor
 	// Close releases the iterator and should be called at the end of iteration
 	io.Closer
 }

--- a/incubator/orm/orm_test.go
+++ b/incubator/orm/orm_test.go
@@ -72,7 +72,7 @@ func TestTypeSafeRowGetter(t *testing.T) {
 			} else {
 				dest = &loadedObj
 			}
-			err := getter(ctx, spec.srcRowID, dest)
+			err := getter.Get(ctx, spec.srcRowID, dest)
 			if spec.expErr != nil {
 				require.True(t, spec.expErr.Is(err), err)
 				return

--- a/incubator/orm/querier.go
+++ b/incubator/orm/querier.go
@@ -118,7 +118,7 @@ func splitPath(path string) (queryArgs, error) {
 }
 
 type RangeQueryParam struct {
-	start, end []byte
+	Start, End []byte
 }
 
 func DoQuery(ctx HasKVStore, index Index, mod string, cursor Cursor, data []byte) (Iterator, error) {
@@ -141,10 +141,10 @@ func DoQuery(ctx HasKVStore, index Index, mod string, cursor Cursor, data []byte
 				return nil, errors.Wrap(err, "unmarshal param")
 			}
 		}
-		if !cursor.InRange(param.start, param.end) {
+		if !cursor.InRange(param.Start, param.End) {
 			return nil, errors.Wrap(ErrArgument, "cursor not in range")
 		}
-		return index.PrefixScan(ctx, cursor.Move(param.start), param.end)
+		return index.PrefixScan(ctx, cursor.Move(param.Start), param.End)
 	default:
 		return nil, errors.Wrapf(ErrArgument, "unknown mod: %s", mod)
 	}

--- a/incubator/orm/querier.go
+++ b/incubator/orm/querier.go
@@ -1,0 +1,143 @@
+package orm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+type Queryable interface {
+	Index
+	GetModelType() reflect.Type
+}
+
+type queryHandler struct {
+	Routes map[string]Queryable
+}
+
+func NewQueryHandler() *queryHandler {
+	return &queryHandler{Routes: make(map[string]Queryable)}
+}
+
+func (h *queryHandler) AddTableRoute(path string, table Table) {
+	if h.Has(path){
+		panic(fmt.Sprintf("path %q exists already", path))
+	}
+	h.Routes[path] = QueryTableAdapter(table)
+}
+
+func (h *queryHandler) AddIndexRoute(path string, index Index) {
+	if h.Has(path) {
+		panic(fmt.Sprintf("path %q exists already", path))
+	}
+	tp, err := GetModelType(index)
+	if err != nil {
+		panic(err)
+	}
+	h.Routes[path] = QueryIndexAdapter(index, tp)
+}
+
+func (h *queryHandler) Has(path string) bool{
+	_, ok := h.Routes[path]
+	return ok
+}
+
+func (h *queryHandler) Handle(ctx sdk.Context, _ []string, req abci.RequestQuery) ([]byte, error) {
+	path, mod := splitPath(req.Path)
+	queryIndex, ok := h.Routes[path]
+	if !ok {
+		return nil, errors.Wrapf(errors.ErrUnknownRequest, "unknown query path: %s", path)
+	}
+	it, err := DoQuery(ctx, queryIndex, mod, req.Data)
+	if err != nil {
+		return nil, err
+	}
+	result, err := buildResult(queryIndex, it)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(&result)
+}
+
+// splitPath splits out the real path along with the query
+// modifier (everything after the ?)
+func splitPath(path string) (string, string) {
+	var mod string
+	chunks := strings.SplitN(path, "?", 2)
+	if len(chunks) == 2 {
+		path = chunks[0]
+		mod = chunks[1]
+	}
+	return path, mod
+}
+
+type RangeQueryParam struct {
+	start, end []byte
+}
+
+func DoQuery(ctx HasKVStore, index Index, mod string, data []byte) (Iterator, error) {
+	switch mod {
+	case KeyQueryMod:
+		return index.Get(ctx, data)
+	case PrefixQueryMod:
+		if len(data) == 0 {
+			return nil, errors.Wrap(ErrArgument, "prefix")
+		}
+		start, end := prefixRange(data)
+		return index.PrefixScan(ctx, start, end)
+	case RangeQueryMod:
+		var param RangeQueryParam
+		if len(data) != 0 {
+			if err := json.Unmarshal(data, &param); err != nil {
+				return nil, errors.Wrap(err, "unmarshal param")
+			}
+		}
+		return index.PrefixScan(ctx, param.start, param.end)
+	default:
+		return nil, errors.Wrapf(ErrArgument, "unknown mod: %s", mod)
+	}
+}
+
+
+type QueryResult struct {
+	Data    []Model `json:"data"`
+	HasMore bool        `json:"has_more"`
+}
+
+func buildResult(queryIndex Queryable, it Iterator) (QueryResult, error) {
+	limitIt := LimitIterator(it, maxQueryResult)
+	defer it.Close()
+
+	mrsh := jsonpb.Marshaler{}
+	var data []Model
+OUTER:
+	for {
+		d := reflect.New(queryIndex.GetModelType()).Interface().(Persistent)
+		id, err := limitIt.LoadNext(d)
+		switch {
+		case ErrIteratorDone.Is(err):
+			break OUTER
+		case err != nil:
+			return QueryResult{}, err
+		default:
+			obj, ok := d.(proto.Message)
+			if !ok {
+				return QueryResult{}, errors.Wrap(ErrArgument, "not proto message")
+			}
+			var buf bytes.Buffer
+			if err := mrsh.Marshal(&buf, obj); err != nil {
+				return QueryResult{}, errors.Wrap(err, "marshal group entity from proto")
+			}
+			data = append(data, Model{Key: id, Value: buf.Bytes()})
+		}
+	}
+	return QueryResult{Data: data, HasMore: limitIt.Remaining() == 0}, nil
+}

--- a/incubator/orm/querier.go
+++ b/incubator/orm/querier.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"reflect"
+	"strconv"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -28,7 +30,7 @@ func NewQueryHandler() *queryHandler {
 }
 
 func (h *queryHandler) AddTableRoute(path string, table Table) {
-	if h.Has(path){
+	if h.Has(path) {
 		panic(fmt.Sprintf("path %q exists already", path))
 	}
 	h.Routes[path] = QueryTableAdapter(table)
@@ -45,45 +47,81 @@ func (h *queryHandler) AddIndexRoute(path string, index Index) {
 	h.Routes[path] = QueryIndexAdapter(index, tp)
 }
 
-func (h *queryHandler) Has(path string) bool{
+func (h *queryHandler) Has(path string) bool {
 	_, ok := h.Routes[path]
 	return ok
 }
 
 func (h *queryHandler) Handle(ctx sdk.Context, _ []string, req abci.RequestQuery) ([]byte, error) {
-	path, mod := splitPath(req.Path)
-	queryIndex, ok := h.Routes[path]
-	if !ok {
-		return nil, errors.Wrapf(errors.ErrUnknownRequest, "unknown query path: %s", path)
-	}
-	it, err := DoQuery(ctx, queryIndex, mod, req.Data)
+	q, err := splitPath(req.Path)
 	if err != nil {
 		return nil, err
 	}
-	result, err := buildResult(queryIndex, it)
+	queryIndex, ok := h.Routes[q.path]
+	if !ok {
+		return nil, errors.Wrapf(errors.ErrUnknownRequest, "unknown query path: %s", q.path)
+	}
+	it, err := DoQuery(ctx, queryIndex, q.mod, q.cursor, req.Data)
+	if err != nil {
+		return nil, err
+	}
+	result, err := buildResult(queryIndex, it, q.limit)
 	if err != nil {
 		return nil, err
 	}
 	return json.Marshal(&result)
 }
 
+type queryArgs struct {
+	path   string
+	mod    string
+	cursor Cursor
+	limit  uint8
+}
+
 // splitPath splits out the real path along with the query
 // modifier (everything after the ?)
-func splitPath(path string) (string, string) {
-	var mod string
+func splitPath(path string) (queryArgs, error) {
+	q := queryArgs{mod: KeyQueryMod, limit: maxQueryResult}
+
 	chunks := strings.SplitN(path, "?", 2)
-	if len(chunks) == 2 {
-		path = chunks[0]
-		mod = chunks[1]
+	if len(chunks) != 2 {
+		q.path = path
+		return q, nil
 	}
-	return path, mod
+	q.path = chunks[0]
+	query, err := url.ParseQuery(chunks[1])
+	if err != nil {
+		return q, err
+	}
+	q.cursor, err = ParseCursor(query.Get(CursorQueryArg))
+	if err != nil {
+		return q, errors.Wrap(err, "cursor")
+	}
+	for _, m := range []string{PrefixQueryMod, RangeQueryMod} {
+		if _, ok := query[m]; ok {
+			q.mod = m
+			break
+		}
+	}
+
+	if rawLimit := query.Get("limit"); rawLimit != "" {
+		l, err := strconv.ParseUint(rawLimit, 10, 8)
+		if err != nil {
+			return q, errors.Wrap(err, "limit")
+		}
+		if new := uint8(l); new > 0 && new < q.limit {
+			q.limit = new
+		}
+	}
+	return q, nil
 }
 
 type RangeQueryParam struct {
 	start, end []byte
 }
 
-func DoQuery(ctx HasKVStore, index Index, mod string, data []byte) (Iterator, error) {
+func DoQuery(ctx HasKVStore, index Index, mod string, cursor Cursor, data []byte) (Iterator, error) {
 	switch mod {
 	case KeyQueryMod:
 		return index.Get(ctx, data)
@@ -92,7 +130,10 @@ func DoQuery(ctx HasKVStore, index Index, mod string, data []byte) (Iterator, er
 			return nil, errors.Wrap(ErrArgument, "prefix")
 		}
 		start, end := prefixRange(data)
-		return index.PrefixScan(ctx, start, end)
+		if !cursor.InRange(start, end) {
+			return nil, errors.Wrap(ErrArgument, "cursor not in range")
+		}
+		return index.PrefixScan(ctx, cursor.Move(start), end)
 	case RangeQueryMod:
 		var param RangeQueryParam
 		if len(data) != 0 {
@@ -100,21 +141,24 @@ func DoQuery(ctx HasKVStore, index Index, mod string, data []byte) (Iterator, er
 				return nil, errors.Wrap(err, "unmarshal param")
 			}
 		}
-		return index.PrefixScan(ctx, param.start, param.end)
+		if !cursor.InRange(param.start, param.end) {
+			return nil, errors.Wrap(ErrArgument, "cursor not in range")
+		}
+		return index.PrefixScan(ctx, cursor.Move(param.start), param.end)
 	default:
 		return nil, errors.Wrapf(ErrArgument, "unknown mod: %s", mod)
 	}
 }
 
-
 type QueryResult struct {
 	Data    []Model `json:"data"`
-	HasMore bool        `json:"has_more"`
+	HasMore bool    `json:"has_more"`
+	Cursor  Cursor  `json:"cursor,omitempty"`
 }
 
-func buildResult(queryIndex Queryable, it Iterator) (QueryResult, error) {
-	limitIt := LimitIterator(it, maxQueryResult)
-	defer it.Close()
+func buildResult(queryIndex Queryable, it Iterator, limit uint8) (QueryResult, error) {
+	limitIt := LimitIterator(it, int(limit))
+	defer limitIt.Close()
 
 	mrsh := jsonpb.Marshaler{}
 	var data []Model
@@ -127,17 +171,18 @@ OUTER:
 			break OUTER
 		case err != nil:
 			return QueryResult{}, err
-		default:
-			obj, ok := d.(proto.Message)
-			if !ok {
-				return QueryResult{}, errors.Wrap(ErrArgument, "not proto message")
-			}
-			var buf bytes.Buffer
-			if err := mrsh.Marshal(&buf, obj); err != nil {
-				return QueryResult{}, errors.Wrap(err, "marshal group entity from proto")
-			}
-			data = append(data, Model{Key: id, Value: buf.Bytes()})
 		}
+		obj, ok := d.(proto.Message)
+		if !ok {
+			return QueryResult{}, errors.Wrap(ErrArgument, "not proto message")
+		}
+		var buf bytes.Buffer
+		if err := mrsh.Marshal(&buf, obj); err != nil {
+			return QueryResult{}, errors.Wrap(err, "marshal group entity from proto")
+		}
+		data = append(data, Model{Key: id, Value: buf.Bytes()})
 	}
-	return QueryResult{Data: data, HasMore: limitIt.Remaining() == 0}, nil
+	cursor := it.NextPosition()
+	hasMore := cursor != nil
+	return QueryResult{Data: data, HasMore: hasMore, Cursor: cursor}, nil
 }

--- a/incubator/orm/query.go
+++ b/incubator/orm/query.go
@@ -1,0 +1,78 @@
+package orm
+
+import (
+	"fmt"
+	"reflect"
+)
+
+const (
+	// KeyQueryMod means to query for exact match (key)
+	KeyQueryMod = ""
+	// PrefixQueryMod means to query for anything with this prefix
+	PrefixQueryMod = "prefix"
+	// RangeQueryMod means to expect complex range query
+	// TODO: implement
+	RangeQueryMod = "range"
+)
+
+const maxQueryResult = 50
+
+
+type queryTableAdapter struct {
+	table Table
+}
+
+func QueryTableAdapter(s TableExportable) queryTableAdapter {
+	return queryTableAdapter{table: s.Table()}
+}
+
+func (t queryTableAdapter) Has(ctx HasKVStore, key []byte) bool {
+	return t.table.Has(ctx, key)
+}
+
+func (t queryTableAdapter) Get(ctx HasKVStore, searchKey []byte) (Iterator, error) {
+	return NewSingleValueIterator(ctx, TableRowGetter(t.table), searchKey), nil
+}
+
+func (t queryTableAdapter) PrefixScan(ctx HasKVStore, start []byte, end []byte) (Iterator, error) {
+	return t.table.PrefixScan(ctx, start, end)
+}
+
+func (t queryTableAdapter) ReversePrefixScan(ctx HasKVStore, start []byte, end []byte) (Iterator, error) {
+	return t.table.ReversePrefixScan(ctx, start, end)
+}
+
+func (t queryTableAdapter) GetModelType() reflect.Type {
+	return t.table.model
+}
+
+type queryIndexAdapter struct {
+	Index
+	model reflect.Type
+}
+
+func QueryIndexAdapter(i Index, model reflect.Type) queryIndexAdapter {
+	return queryIndexAdapter{Index: i, model: model}
+}
+func (t queryIndexAdapter) GetModelType() reflect.Type {
+	return t.model
+}
+
+// ModelTypeExportable this is an extension point for custom index implementations
+type ModelTypeExportable interface{
+	Type() reflect.Type
+}
+
+func GetModelType(s interface{}) (reflect.Type, error) {
+	switch obj := s.(type) {
+	case TableExportable:
+		return obj.Table().model, nil
+	case MultiKeyIndex:
+		return obj.rowGetter.Type(), nil
+	case UniqueIndex:
+		return obj.rowGetter.Type(), nil
+	case ModelTypeExportable:
+		return obj.Type(), nil
+	}
+	return nil, fmt.Errorf("unsupported type %T", s)
+}

--- a/incubator/orm/table.go
+++ b/incubator/orm/table.go
@@ -248,13 +248,20 @@ type typeSafeIterator struct {
 	it        types.Iterator
 }
 
-func (i typeSafeIterator) LoadNext(dest Persistent) (RowID, error) {
+func (i *typeSafeIterator) LoadNext(dest Persistent) (RowID, error) {
 	if !i.it.Valid() {
 		return nil, ErrIteratorDone
 	}
 	rowID := i.it.Key()
 	i.it.Next()
 	return rowID, i.rowGetter.Get(i.ctx, rowID, dest)
+}
+
+func (i typeSafeIterator) NextPosition() Cursor {
+	if !i.it.Valid() {
+		return nil
+	}
+	return i.it.Key()
 }
 
 func (i typeSafeIterator) Close() error {

--- a/incubator/orm/table.go
+++ b/incubator/orm/table.go
@@ -185,8 +185,7 @@ func (a Table) Has(ctx HasKVStore, rowID RowID) bool {
 // GetOne load the object persisted for the given RowID into the dest parameter.
 // If none exists `ErrNotFound` is returned instead. Parameters must not be nil.
 func (a Table) GetOne(ctx HasKVStore, rowID RowID, dest Persistent) error {
-	x := NewTypeSafeRowGetter(a.storeKey, a.prefix, a.model)
-	return x(ctx, rowID, dest)
+	return TableRowGetter(a).Get(ctx, rowID, dest)
 }
 
 // PrefixScan returns an Iterator over a domain of keys in ascending order. End is exclusive.
@@ -212,7 +211,7 @@ func (a Table) PrefixScan(ctx HasKVStore, start, end RowID) (Iterator, error) {
 	store := prefix.NewStore(ctx.KVStore(a.storeKey), []byte{a.prefix})
 	return &typeSafeIterator{
 		ctx:       ctx,
-		rowGetter: NewTypeSafeRowGetter(a.storeKey, a.prefix, a.model),
+		rowGetter: TableRowGetter(a),
 		it:        store.Iterator(start, end),
 	}, nil
 }
@@ -233,7 +232,7 @@ func (a Table) ReversePrefixScan(ctx HasKVStore, start, end RowID) (Iterator, er
 	store := prefix.NewStore(ctx.KVStore(a.storeKey), []byte{a.prefix})
 	return &typeSafeIterator{
 		ctx:       ctx,
-		rowGetter: NewTypeSafeRowGetter(a.storeKey, a.prefix, a.model),
+		rowGetter: TableRowGetter(a),
 		it:        store.ReverseIterator(start, end),
 	}, nil
 }
@@ -245,7 +244,7 @@ func (a Table) Table() Table {
 // typeSafeIterator is initialized with a type safe RowGetter only.
 type typeSafeIterator struct {
 	ctx       HasKVStore
-	rowGetter RowGetter
+	rowGetter TypeSafeRowGetter
 	it        types.Iterator
 }
 
@@ -255,7 +254,7 @@ func (i typeSafeIterator) LoadNext(dest Persistent) (RowID, error) {
 	}
 	rowID := i.it.Key()
 	i.it.Next()
-	return rowID, i.rowGetter(i.ctx, rowID, dest)
+	return rowID, i.rowGetter.Get(i.ctx, rowID, dest)
 }
 
 func (i typeSafeIterator) Close() error {


### PR DESCRIPTION
🚧 Spike
Relates to #30 

I did a little excursus today to demo some weave like query handler. It works with indexes and tables and supports 3 different query modes:
* By Key
* By Prefix
* by Range

In the group module I map the routes to the table and index manually. This is something we probably want to have close to the creation functionality.

A good start to understand the code would be the query [tests](https://github.com/regen-network/cosmos-modules/pull/50/files#diff-ed6ce47e449d64aeaf419a56cdaca5e5R47)


## Included
* Limits
* Pagination

## Not included: 
* Proper tests

## Open questions
* Request + response format
* Encoding of parameters and response data (json or protobuf)
