### PR TITLE
Make orm validation callback optional

### DIFF
--- a/incubator/group/testdata/types.go
+++ b/incubator/group/testdata/types.go
@@ -4,6 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/modules/incubator/group"
+	"github.com/cosmos/modules/incubator/orm"
 )
 
 func (m *MyAppProposal) GetBase() group.ProposalBase {
@@ -32,7 +33,9 @@ func (m *MyAppProposal) SetMsgs(new []sdk.Msg) error {
 	return nil
 }
 
-func (m *MyAppProposal) ValidateBasic() error {
+var _ orm.Validateable = MyAppProposal{}
+
+func (m MyAppProposal) ValidateBasic() error {
 	if err:=m.Base.ValidateBasic(); err!=nil{
 		return errors.Wrap(err, "base")
 	}

--- a/incubator/group/types.go
+++ b/incubator/group/types.go
@@ -48,6 +48,7 @@ type DecisionPolicyResult struct {
 // DecisionPolicy is the persistent set of rules to determine the result of election on a proposal.
 type DecisionPolicy interface {
 	orm.Persistent
+	orm.Validateable
 	Allow(tally Tally, totalPower sdk.Dec, votingDuration time.Duration) (DecisionPolicyResult, error)
 }
 
@@ -126,6 +127,8 @@ func (s StdGroupAccountMetadata) NaturalKey() []byte {
 	return s.Base.NaturalKey()
 }
 
+var _ orm.Validateable = StdGroupAccountMetadata{}
+
 func (s StdGroupAccountMetadata) ValidateBasic() error {
 	if err := s.Base.ValidateBasic(); err != nil {
 		return errors.Wrap(err, "base")
@@ -146,6 +149,8 @@ func (v Vote) NaturalKey() []byte {
 	result = append(result, v.Voter...)
 	return result
 }
+
+var _ orm.Validateable = Vote{}
 
 func (v Vote) ValidateBasic() error {
 	if len(v.Voter) == 0 {
@@ -206,6 +211,8 @@ func noopValidator() subspace.ValueValidatorFn {
 	return func(value interface{}) error { return nil }
 }
 
+var _ orm.Validateable = GroupMetadata{}
+
 func (m GroupMetadata) ValidateBasic() error {
 	if m.Group.Empty() {
 		return sdkerrors.Wrap(ErrEmpty, "group")
@@ -225,6 +232,8 @@ func (m GroupMetadata) ValidateBasic() error {
 	return nil
 }
 
+var _ orm.Validateable = GroupMember{}
+
 func (m GroupMember) ValidateBasic() error {
 	if m.Group.Empty() {
 		return sdkerrors.Wrap(ErrEmpty, "group")
@@ -240,6 +249,8 @@ func (m GroupMember) ValidateBasic() error {
 	}
 	return nil
 }
+
+var _ orm.Validateable = ProposalBase{}
 
 func (p ProposalBase) ValidateBasic() error {
 	if p.GroupAccount.Empty() {

--- a/incubator/orm/orm.go
+++ b/incubator/orm/orm.go
@@ -37,6 +37,12 @@ func (r RowID) Bytes() []byte {
 	return r
 }
 
+// Validateable is an interface that Persistent types can implement and is called on any orm save or update operation.
+type Validateable interface {
+	// ValidateBasic is a sanity check on the data. Any error returned prevents create or updates.
+	ValidateBasic() error
+}
+
 // Persistent supports Marshal and Unmarshal
 //
 // This is separated from Marshal, as this almost always requires
@@ -46,8 +52,6 @@ func (r RowID) Bytes() []byte {
 // As with Marshaller, this may do internal validation on the data
 // and errors should be expected.
 type Persistent interface {
-	// ValidateBasic is a sanity check on the data. Any error returned prevents create or updates.
-	ValidateBasic() error
 	// Marshal serializes object into binary representation
 	Marshal() ([]byte, error)
 	// Unmarshal deserializes the object from the binary representation


### PR DESCRIPTION
After #57 
Introduce an interface for validation callbacks. This decouples the validation from the `orm.Persistence` interface and makes it optional.

Resolves #58 